### PR TITLE
githubapi: Make a deep copy of s.commits map.

### DIFF
--- a/githubapi/githubapi.go
+++ b/githubapi/githubapi.go
@@ -35,11 +35,10 @@ func NewService(clientV3 *githubV3.Client, clientV4 *githubql.Client, user users
 		router = github.DotCom{}
 	}
 	s := &service{
-		clV3:    clientV3,
-		clV4:    clientV4,
-		user:    user,
-		rtr:     router,
-		commits: make(map[string]event.Commit),
+		clV3: clientV3,
+		clV4: clientV4,
+		user: user,
+		rtr:  router,
 	}
 	go s.poll()
 	return s, nil
@@ -53,7 +52,7 @@ type service struct {
 
 	mu         sync.Mutex
 	events     []*githubV3.Event
-	commits    map[string]event.Commit // Not nil. SHA -> Commit.
+	commits    map[string]event.Commit // SHA -> Commit.
 	prs        map[string]bool         // PR API URL -> Pull Request merged.
 	fetchError error
 }
@@ -79,7 +78,10 @@ func (s *service) Log(_ context.Context, event event.Event) error {
 func (s *service) poll() {
 	for {
 		s.mu.Lock()
-		commits := s.commits
+		commits := make(map[string]event.Commit, len(s.commits))
+		for sha, c := range s.commits {
+			commits[sha] = c
+		}
 		s.mu.Unlock()
 		events, commits, prs, pollInterval, fetchError := s.fetchEvents(context.Background(), commits)
 		if fetchError != nil {


### PR DESCRIPTION
Since `commits` gets modified inside `fetchEvents`, it's not viable to make a shallow copy of `s.commits`. That would create race conditions.